### PR TITLE
chore: change Juno deployment to test satellite

### DIFF
--- a/juno.config.ts
+++ b/juno.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "@junobuild/config";
 export default defineConfig({
   satellite: {
     ids: {
-      production: "xavwt-jqaaa-aaaal-asjaa-cai",
+      production: "tdg7b-baaaa-aaaal-asj3a-cai",
     },
     predeploy: ["deno task predeploy"],
     source: "dist",


### PR DESCRIPTION
We just change the Juno satellite to a temporary test one, in order to test the publishing workflows
