### PR TITLE
chore: pin deno version to v2.4.2

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-# Brotli compression does not work with Deno 2.4.4, so pin the version for now
-# TODO: remove once Deno 2.4.4 is fixed, see https://github.com/denoland/deno/issues/30259#issuecomment-3191140500
-deno 2.4.3
+# Brotli compression does not work with Deno 2.4.3 and 2.4.4, so pin the version for now
+# TODO: remove once a patch for Deno is released, see https://github.com/denoland/deno/issues/30259#issuecomment-3191140500
+deno 2.4.2


### PR DESCRIPTION
Downgrading to v2.4.2 seems to work with Brotli compression, see https://github.com/denoland/deno/issues/30259#issue-3279970554