### PR TITLE
chore: rename `agent-js` to `icp-js-core`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository contains the documentation for the ICP JavaScript SDK hosted on
    ```json
    [
      {
-       "repository": "dfinity/icp-sdk-js-core",
+       "repository": "dfinity/icp-js-core",
        "subdirectory": "core"
      },
      // other entries...

--- a/projects-schema.json
+++ b/projects-schema.json
@@ -22,7 +22,7 @@
         "repository": {
           "type": "string",
           "description": "The repository from which to pull the static assets",
-          "examples": ["dfinity/icp-sdk-js-core"]
+          "examples": ["dfinity/icp-js-core"]
         },
         "branch": {
           "type": "string",

--- a/projects.json
+++ b/projects.json
@@ -2,7 +2,7 @@
   "$schema": "./projects-schema.json",
   "projects": [
     {
-      "repository": "dfinity/icp-sdk-js-core",
+      "repository": "dfinity/icp-js-core",
       "branch": "icp-pages",
       "subdirectory": "core"
     }


### PR DESCRIPTION
The repo has been renamed from `dfinity/agent-js` to [dfinity/icp-js-core](https://github.com/dfinity/icp-js-core)