### PR TITLE
chore: adapt generate_changelog to retrieve the secret from the GitHub environment

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -14,5 +14,8 @@ jobs:
     uses: dfinity/ci-tools/.github/workflows/generate-changelog.yaml@main
     with:
       token_app_id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
+      environment: create-prs
+      owner: ${{ github.repository_owner }}
+      repository: ${{ github.event.repository.name }}
     secrets:
       token_private_key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}


### PR DESCRIPTION
The new version of `dfinity/ci-tools/.github/workflows/generate-changelog.yaml` requires a GitHub environment. So this adapts the `generate_changelog` workflow to use the newly created `create-prs` environment which specifies the required `PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY` secret.