### PR TITLE
fix: set environment in the pull-docs job

### DIFF
--- a/.github/workflows/pull-project-docs.yml
+++ b/.github/workflows/pull-project-docs.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   pull-docs:
     runs-on: ubuntu-latest
+    environment: create-prs
 
     steps:
       - name: Create GitHub App Token


### PR DESCRIPTION
The `PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY` secret is now only provided through the `create-prs` environment. So this environment needs to be set from the `pull-docs` job.