### PR TITLE
ci: increase juno deploy upload batch size to 50

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Deploy Docs to Juno satellite
         env:
           JUNO_TOKEN: ${{ secrets.JUNO_TOKEN }}
-        run: deno task juno deploy --mode production --immediate
+        run: deno task juno deploy --mode production --immediate --batch 50
 
       - name: Update Juno satellite config
         env:


### PR DESCRIPTION
Additionally, it updates the juno cli version.
