### PR TITLE
build: bump deno version to v2.5.2

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,1 @@
-# Brotli compression does not work with Deno 2.4.3 and 2.4.4, so pin the version for now
-# TODO: remove once a patch for Deno is released, see https://github.com/denoland/deno/issues/30259#issuecomment-3191140500
-deno 2.4.2
+deno 2.5.2


### PR DESCRIPTION
Follow up of #60.


https://github.com/denoland/deno/pull/30437 seems to have fixed the issues with Brotli compression. It was released in [deno v2.4.5](https://github.com/denoland/deno/releases/tag/v2.4.5)
