### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/commitizen.yml
+++ b/.github/workflows/commitizen.yml
@@ -11,11 +11,11 @@ concurrency:
 jobs:
   check_pr_title:
     if: github.event_name == 'pull_request'
-    uses: dfinity/ci-tools/.github/workflows/check-pr-title.yaml@main
+    uses: dfinity/ci-tools/.github/workflows/check-pr-title.yaml@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main
 
   check_commit_messages:
     if: github.event_name == 'merge_group'
-    uses: dfinity/ci-tools/.github/workflows/check-commit-messages.yaml@main
+    uses: dfinity/ci-tools/.github/workflows/check-commit-messages.yaml@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main
 
   commitizen:
     name: commitizen:required

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   generate_changelog:
-    uses: dfinity/ci-tools/.github/workflows/generate-changelog.yaml@main
+    uses: dfinity/ci-tools/.github/workflows/generate-changelog.yaml@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main
     with:
       token_app_id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
       environment: create-prs

--- a/.github/workflows/pull-project-docs.yml
+++ b/.github/workflows/pull-project-docs.yml
@@ -46,7 +46,7 @@ jobs:
           deno task fetch-project-commit --project "${{ steps.params.outputs.project_repository }}" --token "${{ steps.generate_token.outputs.token }}"
 
       - name: Create pull request
-        uses: dfinity/ci-tools/actions/create-pr@main
+        uses: dfinity/ci-tools/actions/create-pr@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main
         with:
           branch_name: "build/docs-update"
           base_branch_name: "main"


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `dfinity/ci-tools/.github/workflows/check-pr-title.yaml@main` -> `dfinity/ci-tools/.github/workflows/check-pr-title.yaml@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main`
  - Version: main | Latest: ? | Release age: ?
  - Commit: https://github.com/dfinity/ci-tools/commit/afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad

- `dfinity/ci-tools/.github/workflows/check-commit-messages.yaml@main` -> `dfinity/ci-tools/.github/workflows/check-commit-messages.yaml@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main`
  - Version: main | Latest: ? | Release age: ?
  - Commit: https://github.com/dfinity/ci-tools/commit/afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad

- `dfinity/ci-tools/.github/workflows/generate-changelog.yaml@main` -> `dfinity/ci-tools/.github/workflows/generate-changelog.yaml@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main`
  - Version: main | Latest: ? | Release age: ?
  - Commit: https://github.com/dfinity/ci-tools/commit/afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad

- `dfinity/ci-tools/actions/create-pr@main` -> `dfinity/ci-tools/actions/create-pr@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main`
  - Version: main | Latest: ? | Release age: ?
  - Commit: https://github.com/dfinity/ci-tools/commit/afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad


### Files modified

- `.github/workflows/commitizen.yml`
- `.github/workflows/generate-changelog.yml`
- `.github/workflows/pull-project-docs.yml`